### PR TITLE
Create font2mobileconfig.sh

### DIFF
--- a/font2mobileconfig.sh
+++ b/font2mobileconfig.sh
@@ -1,0 +1,51 @@
+#!/bin/sh -
+
+if [ ! "$#" -eq 1 ] ; then
+  /bin/echo "Usage: $0 fontfilename"
+  exit 1
+fi
+
+fontfile=$1
+outfile=$fontfile\.mobileconfig
+outeruuid=`uuidgen`
+inneruuid=`uuidgen`
+/bin/echo -n '<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>PayloadDisplayName</key><string>' > $outfile
+/bin/echo -n $fontfile >> $outfile
+/bin/echo -n '</string>
+<key>PayloadIdentifier</key>
+<string>' >> $outfile
+/bin/echo -n `hostname`.$outeruuid >> $outfile
+/bin/echo -n '</string>
+<key>PayloadType</key><string>Configuration</string>
+<key>PayloadUUID</key><string>' >> $outfile
+/bin/echo -n $outeruuid >> $outfile
+/bin/echo -n '</string>' >> $outfile
+/bin/echo -n '<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadContent</key>
+<array>
+<dict>
+<key>PayloadType</key><string>com.apple.font</string>
+<key>Font</key>
+<data>' >> $outfile
+base64 -b 72 -i $fontfile >> $outfile
+/bin/echo -n '</data>
+<key>Name</key>
+<string>' >> $outfile
+/bin/echo -n $fontfile >> $outfile
+/bin/echo -n '</string>
+<key>PayloadIdentifier</key>
+<string>' >> $outfile
+/bin/echo -n `hostname`.$outeruuid.com.apple.font.$inneruuid >> $outfile
+/bin/echo -n '</string>
+<key>PayloadVersion</key><integer>1</integer>
+<key>PayloadUUID</key><string>' >> $outfile
+/bin/echo -n $inneruuid >> $outfile
+/bin/echo '</string>
+</dict>
+</array>
+</dict>
+</plist>' >> $outfile


### PR DESCRIPTION
This is a script that wraps any file in an Apple mobile provisioning profile as if that file were a font.  If you use the script on a TTF or OTF font file, you'll get a ".mobileconfig" file that can be installed on most versions of iOS or recent versions of OS X to make that font generally available in that environment.

You'll need to have the "uuidgen" and "base64" executables, but all the OS X and Linux systems I checked do have that, so lots of folks should be able to just use this as-is.
