### PR TITLE
Fixed SansBullshitSans.ttx to be valid.

### DIFF
--- a/SansBullshitSans.ttx
+++ b/SansBullshitSans.ttx
@@ -24147,7 +24147,7 @@
               <Ligature components="c,t,i,o,n,a,b,l,e" glyph="uniE601"/>
               <Ligature components="c,t,i,o,n,space,i,t,e,m,s" glyph="uniE600"/>
               <Ligature components="c,c,o,u,n,t,a,b,i,l,i,t,y" glyph="uniE600"/>
-              <Ligature components="t,space,s,c,a,le" glyph="uniE600"/>
+              <Ligature components="t,space,s,c,a,l,e" glyph="uniE600"/>
               <Ligature components="s,space,a,space,s,e,r,v,i,c,e" glyph="uniE600"/>
               <Ligature components="t,space,t,h,e,space,e,n,d,space,o,f,space,t,h,e,space,d,a,y" glyph="uniE600"/>
 
@@ -24466,7 +24466,7 @@
 
               <Ligature components="i,z,a,r,d" glyph="uniE601"/>
               <Ligature components="e,b,i,n,a,r" glyph="uniE601"/>
-              <Ligature components=“e,b,space,s,c,a,l,e” glyph=“uniE601”/>
+              <Ligature components="e,b,space,s,c,a,l,e" glyph="uniE601"/>
               <Ligature components="h,a,t,space,i,s,space,o,u,r,space,s,o,l,v,e" glyph="uniE600"/>
 
             </LigatureSet>


### PR DESCRIPTION
The "at scale" entry was missing a comma and "web scale" entry had smart quotes instead of normal quotes.
